### PR TITLE
Add a github action to check if the repository is a valid binder repo

### DIFF
--- a/.github/workflows/repo2docker.yml
+++ b/.github/workflows/repo2docker.yml
@@ -2,8 +2,6 @@
 name: Validator
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 
@@ -31,7 +29,4 @@ jobs:
 
       - name: Run repo2docker
         shell: bash -l {0}
-        run: |
-            echo ${GITHUB_SHA}
-            echo ${GITHUB_REF}
-            jupyter-repo2docker --no-run --ref ${{ github.ref }} https://github.com/${{ github.repository }}
+        run: jupyter-repo2docker --no-run --ref ${{ github.event.pull_request.head.sha }} https://github.com/${{ github.repository }}

--- a/.github/workflows/repo2docker.yml
+++ b/.github/workflows/repo2docker.yml
@@ -1,0 +1,33 @@
+# This workflow runs repo2docker to check if this repository is a valid binder repo
+name: Run repo2docker
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  repo2docker:
+    name: Run repo2docker
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout current git repository
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Setup Miniconda
+      - name: Setup Miniconda
+        uses: goanpeca/setup-miniconda@v1.3.1
+        with:
+          channels: conda-forge
+
+      - name: Install dependencies
+        run: conda install jupyter-repo2docker
+
+      - name: Show installed package
+        run: conda list
+
+      - name: Run repo2docker
+        run: repo2docker https://github.com/${{ github.repository }}

--- a/.github/workflows/repo2docker.yml
+++ b/.github/workflows/repo2docker.yml
@@ -31,4 +31,7 @@ jobs:
 
       - name: Run repo2docker
         shell: bash -l {0}
-        run: jupyter-repo2docker --no-run --ref ${{ github.ref }} https://github.com/${{ github.repository }}
+        run: |
+            echo ${GITHUB_SHA}
+            echo ${GITHUB_REF}
+            jupyter-repo2docker --no-run --ref ${{ github.ref }} https://github.com/${{ github.repository }}

--- a/.github/workflows/repo2docker.yml
+++ b/.github/workflows/repo2docker.yml
@@ -1,5 +1,5 @@
 # This workflow runs repo2docker to check if this repository is a valid binder repo
-name: Run repo2docker
+name: Validator
 
 on:
   push:
@@ -13,13 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Checkout current git repository
       - name: Checkout
         uses: actions/checkout@v2
 
-      # Setup Miniconda
       - name: Setup Miniconda
-        uses: goanpeca/setup-miniconda@v1.3.1
+        uses: goanpeca/setup-miniconda@v1
         with:
           channels: conda-forge
 
@@ -33,4 +31,4 @@ jobs:
 
       - name: Run repo2docker
         shell: bash -l {0}
-        run: jupyter-repo2docker https://github.com/${{ github.repository }}
+        run: jupyter-repo2docker --no-run --ref ${{ github.sha }} https://github.com/${{ github.repository }}

--- a/.github/workflows/repo2docker.yml
+++ b/.github/workflows/repo2docker.yml
@@ -31,4 +31,4 @@ jobs:
 
       - name: Run repo2docker
         shell: bash -l {0}
-        run: jupyter-repo2docker --no-run --ref ${{ github.sha }} https://github.com/${{ github.repository }}
+        run: jupyter-repo2docker --no-run --ref ${{ github.ref }} https://github.com/${{ github.repository }}

--- a/.github/workflows/repo2docker.yml
+++ b/.github/workflows/repo2docker.yml
@@ -24,10 +24,13 @@ jobs:
           channels: conda-forge
 
       - name: Install dependencies
+        shell: bash -l {0}
         run: conda install jupyter-repo2docker
 
       - name: Show installed package
+        shell: bash -l {0}
         run: conda list
 
       - name: Run repo2docker
-        run: repo2docker https://github.com/${{ github.repository }}
+        shell: bash -l {0}
+        run: jupyter-repo2docker https://github.com/${{ github.repository }}


### PR DESCRIPTION
The binder service runs [jupyter-repo2docker](https://repo2docker.readthedocs.io/) to convert a repository to a docker image. 

This PR adds a github action running `jupyter-repo2docker` to check if a PR is a valid binder repo before merging into master.