### PR TITLE
Add a github action to trigger binder build

### DIFF
--- a/.github/workflows/trigger-binder-build.yml
+++ b/.github/workflows/trigger-binder-build.yml
@@ -1,0 +1,37 @@
+# Trigger a build on binder, so the build is always up to date
+# with the targeted state and users don't have to wait.
+
+name: 'Trigger Binder build'
+on:
+  push:
+    branches:
+      # Only trigger on master branch
+      - master
+      - trigger-build
+
+jobs:
+  trigger-binder-build:
+    runs-on: [ubuntu-latest]
+    steps:
+
+      - name: Trigger build on mybinder.org
+        uses: s-weigand/trigger-mybinder-build@v1
+        with:
+          target-repo: GenericMappingTools/try-gmt
+
+      # Have to trigger build on pangeo manually, because the action above doesn't support it yet
+      - name: Trigger build on binder.pangeo.io
+        # make the command return 0
+        run: |
+            curl -s -L --connect-timeout 10 --max-time 30 https://binder.pangeo.io/build/gh/GenericMappingTools/try-gmt/master
+            curl_return=$?
+            # Return code 28 is when the --max-time is reached
+            if [ "${curl_return}" -eq 0 ] || [ "${curl_return}" -eq 28 ]; then
+                if [[ "${curl_return}" -eq 28 ]]; then
+                    printf "\nBinder build started.\nCheck back soon.\n"
+                fi
+            else
+                exit "${curl_return}"
+            fi
+
+            exit 0

--- a/.github/workflows/trigger-binder-build.yml
+++ b/.github/workflows/trigger-binder-build.yml
@@ -7,7 +7,6 @@ on:
     branches:
       # Only trigger on master branch
       - master
-      - trigger-build
 
 jobs:
   trigger-binder-build:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@ This is an online Jupyter lab with latest
 and [GMT.jl](https://github.com/GenericMappingTools/GMT.jl)
 installed.
 
-You can run it online at [![Pangeo Binder](https://binder.pangeo.io/badge_logo.svg)](https://binder.pangeo.io/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb)
+You can run it online by click one of the badges below:
+
+- [![Binder](https://binder.pangeo.io/badge_logo.svg)](https://binder.pangeo.io/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://binder.pangeo.io
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://mybinder.org/
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://gke.mybinder.org/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://gke.mybinder.org/
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://ovh.mybinder.org//v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://ovh.mybinder.org/
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://gesis.mybinder.org/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://gesis.mybinder.org/
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://turing.mybinder.org/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://turing.mybinder.org/
 
 ## Installed packages
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can run it online by click one of the badges below:
 - [![Binder](https://binder.pangeo.io/badge_logo.svg)](https://binder.pangeo.io/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://binder.pangeo.io
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://mybinder.org/
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://gke.mybinder.org/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://gke.mybinder.org/
-- [![Binder](https://mybinder.org/badge_logo.svg)](https://ovh.mybinder.org//v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://ovh.mybinder.org/
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://ovh.mybinder.org/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://ovh.mybinder.org/
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://gesis.mybinder.org/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://gesis.mybinder.org/
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://turing.mybinder.org/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://turing.mybinder.org/
 


### PR DESCRIPTION
When the repository is updated, the first user who clicks the "launch binder" badge has to wait ~10 minutes for the building of the docker images. After completing the building of docker images,  other users only need ~15 seconds to launch the Jupiter lab. Thus, the first user will have a terrible experience.

To resolve the problem, we need to manually trigger binder builds after the master branch changes. This can be done by using the Binder build API. This github action (https://github.com/marketplace/actions/trigger-binder-build) can trigger binder builds automatically on 5 mybinder services but doesn't support the pangeo binder. 

This PR adds a github action which triggers binder build for the following 6 binder services:

- https://binder.pangeo.io/
-  https://mybinder.org/ (this one is always redirected to the 4 subdomains below)
-  https://gke.mybinder.org/
-  https://ovh.mybinder.org/
-  https://gesis.mybinder.org/
-  https://turing.mybinder.org/

The links of the 6 binder services are all listed in the README, so that users can have more choices if one is not responding.



