### PR TITLE
WIP: Fix Julia version to 1.5.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,5 +3,5 @@ GMT = "5752ebe1-31b9-557e-87aa-f909b540aa54"
 IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
 
 [compat]
-julia = "1.5"
+julia = "=1.5.2"
 GMT = "0.25.0"


### PR DESCRIPTION
`julia = '1.5'` in Project.toml doesn't mean the installed julia version is 1.5.
To specify the julia version, we need to use `julia = "=x.y.z"`.

See https://discourse.julialang.org/t/ann-mybinder-org-support-for-julia-1-x-and-project-toml/22522/27
for discussions.