### PR TITLE
Update pygmt to v0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can run it online by click one of the badges below:
 
 - **GMT**: 6.1.1
 - **Python**: 3.9
-- **PyGMT**: 0.3.0
+- **PyGMT**: 0.3.1
 - **Julia**: 1.5
 - **GMT.jl**: 0.30.1
 

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,6 @@ channels:
 dependencies:
   - python=3.9
   - gmt=6.1.1
-  - pygmt=0.3.0
+  - pygmt=0.3.1
   - jupyterlab=3.0.7
   - jupyter-offlinenotebook=0.2.1


### PR DESCRIPTION
With the [release](https://github.com/GenericMappingTools/pygmt/issues/987) of pygmt v0.3.1, this updates the version in try-gmt.