### PR TITLE
Bump to GMT 6.2.0

### DIFF
--- a/.github/workflows/repo2docker.yml
+++ b/.github/workflows/repo2docker.yml
@@ -29,4 +29,4 @@ jobs:
 
       - name: Run repo2docker
         shell: bash -l {0}
-        run: jupyter-repo2docker --no-run --ref ${{ github.event.pull_request.head.sha }} https://github.com/${{ github.repository }}
+        run: jupyter-repo2docker --no-run --ref ${{ github.event.pull_request.head.sha }} https://github.com/${{ github.event.repository.name }}

--- a/.github/workflows/repo2docker.yml
+++ b/.github/workflows/repo2docker.yml
@@ -29,4 +29,4 @@ jobs:
 
       - name: Run repo2docker
         shell: bash -l {0}
-        run: jupyter-repo2docker --no-run --ref ${{ github.event.pull_request.head.sha }} https://github.com/${{ github.event.repository.name }}
+        run: jupyter-repo2docker --no-run --ref ${{ github.event.pull_request.head.sha }} https://github.com/${{ github.event.pull_request.head.repo.full_name }}

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - python=3.9
-  - gmt=6.1.1
+  - gmt=6.2.0
   - pygmt=0.3.1
   - jupyterlab=3.0.7
   - jupyter-offlinenotebook=0.2.1


### PR DESCRIPTION
Release on https://github.com/GenericMappingTools/gmt/releases/tag/6.2.0.