### PR TITLE
Add geopandas dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Try GMT, PyGMT, and GMT.jl online
 
-This is an online Jupyter lab with latest
+This is an online Jupyter lab environment with the latest
 [GMT](https://www.generic-mapping-tools.org/),
 [PyGMT](https://www.pygmt.org/),
-and [GMT.jl](https://github.com/GenericMappingTools/GMT.jl)
-installed.
+and [GMT.jl](https://www.generic-mapping-tools.org/GMT.jl/)
+versions installed.
 
-You can run it online by click one of the badges below:
+Run it online by clicking on one of the badges below:
 
 - [![Binder](https://binder.pangeo.io/badge_logo.svg)](https://binder.pangeo.io/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://binder.pangeo.io
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://mybinder.org/
@@ -14,15 +14,16 @@ You can run it online by click one of the badges below:
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://ovh.mybinder.org/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://ovh.mybinder.org/
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://gesis.mybinder.org/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://gesis.mybinder.org/
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://turing.mybinder.org/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://turing.mybinder.org/
-- [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/GenericMappingTools/try-gmt/blob/master/landing-page.ipynb) hosted by [Google Colab](https://colab.research.google.com/) (Need to log in to your Google account).
+- [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/GenericMappingTools/try-gmt/blob/master/landing-page.ipynb) hosted by [Google Colab](https://colab.research.google.com/) (Currently broken, see https://github.com/GenericMappingTools/try-gmt/issues/17. Need to log in to your Google account).
 
 ## Installed packages
 
 - **GMT**: 6.2.0
-- **Python**: 3.9
-- **PyGMT**: 0.4.0
 - **Julia**: 1.6
 - **GMT.jl**: 0.34.0
+- **Python**: 3.9
+- **PyGMT**: 0.4.0
+- **Geopandas**: 0.9.0
 
 ## Reference
 

--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,5 @@ dependencies:
   - pygmt=0.4.0
   - jupyterlab=3.0.16
   - jupyter-offlinenotebook=0.2.1
+  # Optional dependencies
+  - geopandas=0.9.0


### PR DESCRIPTION
Adds the optional `geopandas` dependency so PyGMT can test it out easily. Fixes #24. I've also updated the README.md to mention that Google Colab is currently broken as per #17.