### PR TITLE
Remove Pangeo Binder link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ versions installed.
 
 Run it online by clicking on one of the badges below:
 
-- [![Binder](https://binder.pangeo.io/badge_logo.svg)](https://binder.pangeo.io/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://binder.pangeo.io
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://mybinder.org/
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://gke.mybinder.org/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://gke.mybinder.org/
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://ovh.mybinder.org/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://ovh.mybinder.org/


### PR DESCRIPTION
They shut down the server in Dec 2021, and unfortunately it doesn't look like it'll come back up. See https://github.com/pangeo-data/pangeo-binder/issues/195

There does seem to be some work going on at 2i2c to create an authenticated-only deployment, but I'm not quite sure how that can be linked to this GitHub repo, so let's just stick with the mybinder.org federation for now.