### PR TITLE
Bump pygmt from 0.7.0 to 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Run it online by clicking on one of the badges below:
 - **GMT**: 6.4.0
 - **Julia**: 1.7
 - **GMT.jl**: 0.41.4
-- **Python**: 3.10
-- **PyGMT**: 0.7.0
-- **Geopandas**: 0.11.0
+- **Python**: 3.11
+- **PyGMT**: 0.8.0
+- **Geopandas**: 0.12.2
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Run it online by clicking on one of the badges below:
 - **GMT**: 6.4.0
 - **Julia**: 1.7
 - **GMT.jl**: 0.41.4
-- **Python**: 3.11
+- **Python**: 3.10
 - **PyGMT**: 0.8.0
 - **Geopandas**: 0.12.2
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,10 +3,10 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.10
+  - python=3.11
   - gmt=6.4.0
   - pygmt=0.8.0
-  - jupyterlab=3.4.0
+  - jupyterlab=3.5.2
   - jupyter-offlinenotebook=0.2.2
   # Optional dependencies
   - geopandas=0.12.2

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.11
+  - python=3.10
   - gmt=6.4.0
   - pygmt=0.8.0
   - jupyterlab=3.5.2

--- a/environment.yml
+++ b/environment.yml
@@ -5,8 +5,8 @@ channels:
 dependencies:
   - python=3.10
   - gmt=6.4.0
-  - pygmt=0.7.0
+  - pygmt=0.8.0
   - jupyterlab=3.4.0
   - jupyter-offlinenotebook=0.2.2
   # Optional dependencies
-  - geopandas=0.11.0
+  - geopandas=0.12.2


### PR DESCRIPTION
Supersedes #39. Part of https://github.com/GenericMappingTools/pygmt/issues/2244.

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/GenericMappingTools/try-gmt/pygmt-v0.8.0)