### PR TITLE
Update the Python demo to use load_earth_relief function and update deprecated parameters

### DIFF
--- a/python-demo.ipynb
+++ b/python-demo.ipynb
@@ -190,11 +190,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pygmt.datasets import load_earth_relief\n",
+    "\n",
+    "grid = load_earth_relief(resolution='01d', registration='pixel')\n",
+    "\n",
     "fig = pygmt.Figure()\n",
     "fig.basemap(region='g', projection='G200/30/12c', frame=True)\n",
-    "fig.grdimage('@earth_relief_20m', cmap='geo', shading=True)\n",
+    "fig.grdimage(grid, cmap='geo', shading=True)\n",
     "fig.coast(resolution='c', shorelines=True, area_thresh=1000)\n",
-    "fig.plot(data='@hotspots.txt', style='c0.2c', color='red')\n",
+    "fig.plot(data='@hotspots.txt', style='c0.2c', fill='red')\n",
     "fig.colorbar()\n",
     "fig.show()"
    ]


### PR DESCRIPTION
Changes in this PR:

- Load the Earth relief dataset using `load_earth_relief` and pass it to `grdimage`
- Update `color` to `fill` in `Figure.plot()`