### PR TITLE
Update the instructions to run on Google Colab

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Run it online by clicking on one of the badges below:
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://ovh.mybinder.org/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://ovh.mybinder.org/
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://gesis.mybinder.org/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://gesis.mybinder.org/
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://turing.mybinder.org/v2/gh/GenericMappingTools/try-gmt/master?urlpath=lab/tree/landing-page.ipynb) hosted at https://turing.mybinder.org/
-- [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/GenericMappingTools/try-gmt/blob/master/landing-page.ipynb) hosted by [Google Colab](https://colab.research.google.com/) (Currently broken, see https://github.com/GenericMappingTools/try-gmt/issues/17. Need to log in to your Google account).
+- [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/GenericMappingTools/try-gmt/blob/master/landing-page.ipynb) hosted by [Google Colab](https://colab.research.google.com/) (Need to log in to your Google account).
 
 ## Installed packages
 

--- a/python-demo.ipynb
+++ b/python-demo.ipynb
@@ -32,13 +32,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
-    "## Note for Google Colab users\n",
+    "## Google Colab users: Follow these instructions before your start!\n",
     "\n",
-    "Google Colab doesn't have PyGMT and its dependencies installed. You need to run the following commands to install them once.\n",
+    "**Google Colab** doesn't have PyGMT and its dependencies installed. You need to follow the instructions below to install them.\n",
     "\n",
-    "Be patient! The installation may take a few minutes."
+    "First, we need to install conda on Google Colab. The installation process is greatly simplified using the [condacolab](https://github.com/conda-incubator/condacolab) package.\n",
+    "\n",
+    "*After condacolab finishes the installation, it will restart the Python kernel for changes to be applied. This happens automatically. Thus, you will see a message saying \"Your session crashed for an unknown reason\". You can safely ignore this message!*"
    ]
   },
   {
@@ -47,17 +51,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh\n",
-    "!chmod +x Miniconda3-latest-Linux-x86_64.sh\n",
-    "!bash ./Miniconda3-latest-Linux-x86_64.sh -bfp /usr/local\n",
-    "!conda update conda -y -q\n",
-    "!conda config --prepend channels conda-forge\n",
-    "!conda install -q -y --prefix /usr/local python=3.7 pygmt\n",
-    "\n",
-    "import sys\n",
-    "import os\n",
-    "sys.path.append('/usr/local/lib/python3.7/site-packages')\n",
-    "os.environ[\"GMT_LIBRARY_PATH\"]=\"/usr/local/lib\""
+    "!pip install -q condacolab\n",
+    "import condacolab\n",
+    "condacolab.install()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can install PyGMT and its dependencies using a single command. The installation may take a few minutes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!mamba install pygmt"
    ]
   },
   {
@@ -231,7 +243,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -245,7 +257,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The installation process is greatly simplified using the [condacolab](https://github.com/conda-incubator/condacolab) package!

[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/GenericMappingTools/try-gmt/blob/google-colab/python-demo.ipynb)

Closes https://github.com/GenericMappingTools/try-gmt/issues/17. Supersedes https://github.com/GenericMappingTools/try-gmt/pull/37.

