### PR TITLE
Bump pygmt from 0.11.0 to 0.12.0, geopandas to 0.14.0, jupyterlab to 4.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Run it online by clicking on one of the badges below:
 - **Julia**: 1.7
 - **GMT.jl**: 1.x
 - **Python**: 3.11
-- **PyGMT**: 0.10.0
+- **PyGMT**: 0.12.0
 - **Geopandas**: 0.12.2
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Run it online by clicking on one of the badges below:
 - **GMT.jl**: 1.x
 - **Python**: 3.11
 - **PyGMT**: 0.12.0
-- **Geopandas**: 0.12.2
+- **Geopandas**: 0.14.4
 
 ## Reference
 

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.11
   - gmt=6.5.0
-  - pygmt=0.11.0
+  - pygmt=0.12.0
   - jupyterlab=3.6.3
   - jupyter-offlinenotebook=0.2.2
   # Optional dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,4 @@ dependencies:
   - jupyterlab=3.6.3
   - jupyter-offlinenotebook=0.2.2
   # Optional dependencies
-  - geopandas=0.14.3
+  - geopandas=0.14.4

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.11
   - gmt=6.5.0
   - pygmt=0.12.0
-  - jupyterlab=3.6.3
+  - jupyterlab=4.1.8
   - jupyter-offlinenotebook=0.2.2
   # Optional dependencies
   - geopandas=0.14.4


### PR DESCRIPTION
Supersedes #51, part of https://github.com/GenericMappingTools/pygmt/issues/3180


[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/GenericMappingTools/try-gmt/pygmt-v0.12.0)