### PR TITLE
Add Binder URLs to GESIS notebooks and Curvenote

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Run it online by clicking on one of the badges below:
 
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/GenericMappingTools/try-gmt/main?urlpath=lab/tree/landing-page.ipynb) hosted at https://mybinder.org/
 - [![Binder](https://mybinder.org/badge_logo.svg)](https://ovh.mybinder.org/v2/gh/GenericMappingTools/try-gmt/main?urlpath=lab/tree/landing-page.ipynb) hosted at https://ovh.mybinder.org/
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://notebooks.gesis.org/binder/v2/gh/GenericMappingTools/try-gmt/main?urlpath=lab/tree/landing-page.ipynb) hosted at https://notebooks.gesis.org/binder/
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://binder.curvenote.dev/v2/gh/GenericMappingTools/try-gmt/main?urlpath=lab/tree/landing-page.ipynb) hosted at https://binder.curvenote.dev/
 - [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/GenericMappingTools/try-gmt/blob/main/landing-page.ipynb) hosted by [Google Colab](https://colab.research.google.com/) (Need to log in to your Google account).
 
 ## Installed packages


### PR DESCRIPTION
Update links to include two more hubs that are part of the BinderHub Federation - https://mybinder.readthedocs.io/en/latest/about/federation.html#members-of-the-binderhub-federation

![image](https://github.com/user-attachments/assets/0b43b3fb-edc5-498c-82ae-d258403500e4)

Test at:
- [GESIS Notebooks](https://notebooks.gesis.org/binder/) - [![Binder](https://mybinder.org/badge_logo.svg)](https://notebooks.gesis.org/binder/v2/gh/GenericMappingTools/try-gmt/main?urlpath=lab/tree/landing-page.ipynb) (4GB of RAM)
- [Curvenote](https://binder.curvenote.dev/) - [![Binder](https://mybinder.org/badge_logo.svg)](https://binder.curvenote.dev/v2/gh/GenericMappingTools/try-gmt/main?urlpath=lab/tree/landing-page.ipynb) (2GB of RAM)

Note that GESIS notebook was previously removed at commit https://github.com/GenericMappingTools/try-gmt/commit/b8a7407c9af326a9a2102358f6c91e2deb507d43#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L14, but it is back now under a diffferent URL.