### PR TITLE
Bump pygmt from 0.16.0 to 0.17.0, geopandas to 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Run it online by clicking on one of the badges below:
 - **GMT.jl**: 1.x
 - **Python**: 3.13
 - **PyGMT**: 0.17.0
-- **Geopandas**: 1.0.1
+- **Geopandas**: 1.1.1
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Run it online by clicking on one of the badges below:
 - **Julia**: 1.10
 - **GMT.jl**: 1.x
 - **Python**: 3.13
-- **PyGMT**: 0.16.0
+- **PyGMT**: 0.17.0
 - **Geopandas**: 1.0.1
 
 ## Reference

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.13
   - gmt=6.6.0
-  - pygmt=0.16.0
+  - pygmt=0.17.0
   - jupyterlab=4.3.6
   - jupyter-offlinenotebook=0.3.1
   # Optional dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,4 @@ dependencies:
   - jupyterlab=4.3.6
   - jupyter-offlinenotebook=0.3.1
   # Optional dependencies
-  - geopandas=1.0.1
+  - geopandas=1.1.1


### PR DESCRIPTION
Supersedes #58, part of https://github.com/GenericMappingTools/pygmt/issues/4100

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/GenericMappingTools/try-gmt/pygmt-v0.17.0)